### PR TITLE
Improve UI with placeholder images and login redirect

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -3,9 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { api } from '../lib/api';
 
-function CardSkeleton(){ return <div className="h-64 rounded bg-gray-100 animate-pulse" /> }
+function CardSkeleton() {
+  return <div className="h-64 rounded bg-gray-100 animate-pulse" />;
+}
 
-export default function Home(){
+export default function Home() {
   const [q, setQ] = useState('');
   const [city, setCity] = useState('');
 
@@ -15,54 +17,53 @@ export default function Home(){
   });
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-col sm:flex-row gap-2 sm:items-end">
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row gap-2 sm:items-end bg-white p-4 rounded shadow">
         <div>
           <label className="text-sm">Search</label>
-          <input className="border p-2 w-72 block rounded" placeholder="Hotel or city" value={q} onChange={e=>setQ(e.target.value)} />
+          <input className="border p-2 w-72 block rounded" placeholder="Hotel or city" value={q} onChange={e => setQ(e.target.value)} />
         </div>
         <div>
           <label className="text-sm">City</label>
-          <input className="border p-2 w-56 block rounded" value={city} onChange={e=>setCity(e.target.value)} />
+          <input className="border p-2 w-56 block rounded" value={city} onChange={e => setCity(e.target.value)} />
         </div>
-        <button onClick={()=>refetch()} className="h-10 px-4 bg-black text-white rounded">Search</button>
+        <button onClick={() => refetch()} className="h-10 px-4 bg-black text-white rounded">Search</button>
       </div>
 
       {error && <p className="text-red-600">Failed to load hotels</p>}
 
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
         {isLoading
-          ? Array.from({length:6}).map((_,i)=><CardSkeleton key={i}/>)
-          : (data||[]).map(h => (
-              <div key={h.id} className="border bg-white rounded overflow-hidden hover:shadow-md transition">
-                {h.primary_image
-                  ? <img src={h.primary_image} alt={h.name} className="h-40 w-full object-cover" />
-                  : <div className="h-40 w-full bg-gray-100" />}
-                <div className="p-3">
-                  <div className="flex items-center justify-between">
-                    <h3 className="font-semibold">{h.name}</h3>
-                    <span className="text-xs px-2 py-0.5 rounded-full border">
-                      {h.occupancy.hotel_status}
-                    </span>
-                  </div>
-                  <p className="text-sm text-gray-600">{h.city}, {h.country}</p>
-                  {h.sample_room_types?.length > 0 && (
-                    <div className="mt-2 text-sm space-y-1">
-                      {h.sample_room_types.map(rt => (
-                        <div key={rt.id} className="flex justify-between text-gray-700">
-                          <span>{rt.name} · {rt.capacity} pax</span>
-                          <span>${rt.base_price}</span>
-                        </div>
-                      ))}
+          ? Array.from({ length: 6 }).map((_, i) => <CardSkeleton key={i} />)
+          : (data || []).map(h => {
+              const imgSrc = h.primary_image || `https://source.unsplash.com/random/400x300/?hotel&sig=${h.id}`;
+              return (
+                <div key={h.id} className="border bg-white rounded overflow-hidden shadow-sm hover:shadow-lg transition-transform hover:-translate-y-1">
+                  <img src={imgSrc} alt={h.name} className="h-40 w-full object-cover" />
+                  <div className="p-3 space-y-2">
+                    <div className="flex items-center justify-between">
+                      <h3 className="font-semibold">{h.name}</h3>
+                      <span className="text-xs px-2 py-0.5 rounded-full border">{h.occupancy.hotel_status}</span>
                     </div>
-                  )}
-                  <div className="mt-3 flex gap-2">
-                    <Link to={`/hotels/${h.id}`} className="px-3 py-2 border rounded">Details</Link>
-                    <Link to={`/hotels/${h.id}`} className="px-3 py-2 bg-black text-white rounded">Book Now</Link>
+                    <p className="text-sm text-gray-600">{h.city}, {h.country}</p>
+                    {h.sample_room_types?.length > 0 && (
+                      <div className="mt-2 text-sm space-y-1">
+                        {h.sample_room_types.map(rt => (
+                          <div key={rt.id} className="flex justify-between text-gray-700">
+                            <span>{rt.name} · {rt.capacity} pax</span>
+                            <span>${rt.base_price}</span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    <div className="mt-3 flex gap-2">
+                      <Link to={`/hotels/${h.id}`} className="px-3 py-2 border rounded">Details</Link>
+                      <Link to={`/hotels/${h.id}`} className="px-3 py-2 bg-black text-white rounded">Book Now</Link>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))
+              );
+            })
         }
       </div>
     </div>

--- a/frontend/src/pages/HotelDetail.jsx
+++ b/frontend/src/pages/HotelDetail.jsx
@@ -26,6 +26,9 @@ export default function HotelDetail(){
 
   const h = data.hotel;
   const availability = data.availability || {};
+  const images = h.images?.length > 0
+    ? h.images
+    : [{ id: 'ph', url: `https://source.unsplash.com/random/800x600/?hotel&sig=${h.id}`, alt_text: h.name }];
 
   const openModal = (rt) => {
     if (!checkIn || !checkOut) { toast.error('Pick dates first'); return; }
@@ -34,17 +37,15 @@ export default function HotelDetail(){
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <h1 className="text-2xl font-bold">{h.name}</h1>
       <p className="text-gray-600">{h.city}, {h.country}</p>
 
-      {h.images?.length > 0 && (
-        <div className="flex gap-2 overflow-x-auto">
-          {h.images.map(img => (
-            <img key={img.id} src={img.url} alt={img.alt_text || h.name} className="h-40 rounded" />
-          ))}
-        </div>
-      )}
+      <div className="flex gap-2 overflow-x-auto rounded">
+        {images.map(img => (
+          <img key={img.id} src={img.url} alt={img.alt_text || h.name} className="h-40 rounded" />
+        ))}
+      </div>
 
       <div className="flex gap-2 items-end">
         <div>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,32 +1,48 @@
-import { useState } from 'react'
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-export default function Login(){
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [msg, setMsg] = useState('')
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [msg, setMsg] = useState('');
+  const nav = useNavigate();
 
-  const submit = async (e)=>{
-    e.preventDefault()
-    setMsg('')
-    try{
-      const res = await fetch(import.meta.env.VITE_API_BASE_URL + '/auth/login',{
-        method:'POST', headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({email, password})
-      })
-      const data = await res.json()
-      if(!res.ok) throw new Error(data.error || 'Login failed')
-      localStorage.setItem('access_token', data.access_token)
-      setMsg('Logged in!')
-    }catch(err){ setMsg(err.message) }
-  }
+  const submit = async (e) => {
+    e.preventDefault();
+    setMsg('');
+    try {
+      const res = await fetch(import.meta.env.VITE_API_BASE_URL + '/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Login failed');
+      localStorage.setItem('access_token', data.access_token);
+      nav('/');
+    } catch (err) {
+      setMsg(err.message);
+    }
+  };
 
   return (
-    <form onSubmit={submit} className="max-w-sm space-y-3">
+    <form onSubmit={submit} className="max-w-sm space-y-4 p-4 bg-white rounded shadow">
       <h1 className="text-xl font-semibold">Login</h1>
-      <input className="border p-2 w-full" placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} />
-      <input className="border p-2 w-full" placeholder="Password" type="password" value={password} onChange={e=>setPassword(e.target.value)} />
-      <button className="bg-black text-white px-3 py-2 rounded">Login</button>
-      {msg && <p className="text-sm text-gray-600">{msg}</p>}
+      <input
+        className="border p-2 w-full rounded"
+        placeholder="Email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+      />
+      <input
+        className="border p-2 w-full rounded"
+        placeholder="Password"
+        type="password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      <button className="bg-black text-white px-3 py-2 rounded w-full">Login</button>
+      {msg && <p className="text-sm text-red-600 text-center">{msg}</p>}
     </form>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- Redirect users to home after successful login and enhance login styling
- Show hotel cards with Unsplash fallback images and improved card design
- Provide placeholder gallery images on hotel detail pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cb524d41c8320a2d14012b0e89d25